### PR TITLE
Added separate bindkey commands for Mac users in the .zshrc file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,16 @@ zpm load loiccoyle/zsh-github-copilot
 
 Bind the **suggest** and/or **explain** widgets:
 
+### For Linux/Windows:
 ```zsh
 bindkey '^[|' zsh_gh_copilot_explain  # bind Alt+shift+\ to explain
 bindkey '^[\' zsh_gh_copilot_suggest  # bind Alt+\ to suggest
+```
+
+### For Mac:
+```zsh
+bindkey '¿' zsh_gh_copilot_explain  # bind Option+shift+\ to explain
+bindkey '÷' zsh_gh_copilot_suggest  # bind Option+\ to suggest
 ```
 
 ### Explanations


### PR DESCRIPTION
This pull request updates the .zshrc configuration file to include separate bindkey commands for Mac users. This change ensures that the key bindings for the GitHub Copilot suggestions and explanations are correctly set up for both Linux/Windows and Mac environments.