### PR TITLE
Use main branch with antigen

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Requires the [GitHub CLI](https://github.com/cli/cli) with the [Copilot extensio
 Add the following to your `.zshrc`:
 
 ```zsh
-antigen bundle loiccoyle/zsh-github-copilot
+antigen bundle loiccoyle/zsh-github-copilot@main
 ```
 
 ### [oh-my-zsh](http://github.com/robbyrussell/oh-my-zsh)


### PR DESCRIPTION
The suggested `antigen` command fails with the following error:

```
$ antigen bundle loiccoyle/zsh-github-copilot

Installing loiccoyle/zsh-github-copilot... Cloning into '~/.antigen/bundles/loiccoyle/zsh-github-copilot'...
warning: Could not find remote branch master to clone.
fatal: Remote branch master not found in upstream origin
Error! Activate logging and try again.
```

This PR fixes it by telling antigen to use the main branch instead as described in https://github.com/zsh-users/antigen/issues/717